### PR TITLE
Fix segfault when setting reptype of a polyhedron

### DIFF
--- a/cdd.pyx
+++ b/cdd.pyx
@@ -775,8 +775,12 @@ cdef class Polyhedron(NumberTypeable):
                 return self.dd_poly.representation
             else:
                 return self.ddf_poly.representation
+
         def __set__(self, dd_RepresentationType value):
-            self.dd_poly.representation = value
+            if self.dd_poly:
+                self.dd_poly.representation = value
+            else:
+                self.ddf_poly.representation = <ddf_RepresentationType>value
 
     def __str__(self):
         """Print the polyhedra data."""

--- a/test/test_set_poly_reptype.py
+++ b/test/test_set_poly_reptype.py
@@ -1,0 +1,25 @@
+import cdd
+
+def test_set_float_polyhedron_rep_type():
+    mat = cdd.Matrix([[1, 0, 1], [1, 1, 0], [1, 1, 1], [1, 0, 0]],
+                     number_type='float')
+    mat.rep_type = cdd.RepType.GENERATOR
+
+    poly = cdd.Polyhedron(mat)
+
+    poly.rep_type = cdd.RepType.INEQUALITY
+    assert(poly.rep_type == cdd.RepType.INEQUALITY)
+    poly.rep_type = cdd.RepType.GENERATOR
+    assert(poly.rep_type == cdd.RepType.GENERATOR)
+
+def test_set_frac_polyhedron_rep_type():
+    mat = cdd.Matrix([[1, 0, 1], [1, 1, 0], [1, 1, 1], [1, 0, 0]],
+                     number_type='fraction')
+    mat.rep_type = cdd.RepType.GENERATOR
+
+    poly = cdd.Polyhedron(mat)
+
+    poly.rep_type = cdd.RepType.INEQUALITY
+    assert(poly.rep_type == cdd.RepType.INEQUALITY)
+    poly.rep_type = cdd.RepType.GENERATOR
+    assert(poly.rep_type == cdd.RepType.GENERATOR)


### PR DESCRIPTION
This fixes #16 :

The issue is that when setting the rep_type, dd_poly was always used, resulting in a segfault when using the floating point mode. This PR simply checks which poly is currently in use and sets the right representation.