### PR TITLE
Fix rational cdd.Matrix from np.array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - pip install --install-option="--no-cython-compile" Cython
   - "pip install Sphinx"
   - "pip install nose"
+  - "pip install numpy"
   - "pip install ."
 script:
   - "nosetests"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -77,7 +77,7 @@ install:
   #       because the v90 msbuild does not parse the vc10 project file
   - "msbuild mpir-3.0.0/build.vc14/lib_mpir_gc/lib_mpir_gc.vcxproj /p:Configuration=Release /p:Platform=%PLATFORM% /p:PlatformToolset=%PLATFORMTOOLSET% /verbosity:normal"
   - "%CMD_IN_ENV% pip install --install-option=\"--no-cython-compile\" Cython"
-  - "%CMD_IN_ENV% pip install Sphinx nose wheel"
+  - "%CMD_IN_ENV% pip install Sphinx nose wheel numpy"
   - "%CMD_IN_ENV% python setup.py build build_ext -Impir-3.0.0/lib/%PLATFORM%/Release/ -Lmpir-3.0.0/build.vc14/lib_mpir_gc/%PLATFORM%/Release/"
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
   - ps: "ls dist"

--- a/cdd.pyx
+++ b/cdd.pyx
@@ -24,6 +24,7 @@ cimport libc.stdio
 cimport libc.stdlib
 
 from fractions import Fraction
+import numbers
 
 __version__ = "1.0.6"
 
@@ -212,7 +213,7 @@ cdef _set_mytype(mytype target, value):
     # set target to value
     if isinstance(value, float):
         dd_set_d(target, value)
-    elif isinstance(value, (Fraction, int, long)):
+    elif isinstance(value, numbers.Rational):
         try:
             dd_set_si2(target, value.numerator, value.denominator)
         except OverflowError:

--- a/test/test_issue20.py
+++ b/test/test_issue20.py
@@ -1,0 +1,21 @@
+import cdd
+import numpy as np
+
+
+def test_issue20():
+    A = np.array([[1, 0, 0],
+                  [1, 1, 0],
+                  [1, 0, 1]])
+
+    ref_ineq = np.array([[1, -1, -1],
+                         [0, 1, 0],
+                         [0, 0, 1]])
+
+    mat = cdd.Matrix(A, number_type='fraction')
+    mat.rep_type = cdd.RepType.GENERATOR
+
+    cdd_poly = cdd.Polyhedron(mat)
+
+    ineq = np.array(cdd_poly.get_inequalities())
+
+    assert(((ref_ineq - ineq) == 0).all())


### PR DESCRIPTION
Because `np.int` types are no longer subtypes of `builtins.int`, test instead for `numbers.Rational`, thus fixing creation of fractional `cdd.Matrix`  from a `numpy.array<int64>`. This would previously fail to fill the array.

I also added a test, which requires `numpy` to be ran.

This would fix #20 .

