### PR TITLE
Expose adjacency list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Version 2.1.1 (in development)
 ------------------------------
 
+* exposed adjacency list (see issue #33,
+  contributed by bobmyhill)
+  
 Version 2.1.0 (15 October 2018)
 -------------------------------
 

--- a/cdd.pyx
+++ b/cdd.pyx
@@ -167,7 +167,7 @@ cdef _get_dd_setvector(dd_SetVector set_vector,
 cdef _get_ddf_setvector(ddf_SetVector set_vector,
                         int famsize, int setsize):
     """
-    Create tuple of Python frozensets from dd_SetVector.
+    Create tuple of Python frozensets from ddf_SetVector.
     The indexing of the sets start at 0, unlike the
     string output from the SetFamily class,
     which starts at 1.
@@ -746,8 +746,8 @@ cdef class SetFamily(NumberTypeable):
                                          self.dd_setfamily.setsize)
             else:
                 return _get_ddf_setvector(self.ddf_setfamily.set,
-                                          self.dd_setfamily.famsize,
-                                          self.dd_setfamily.setsize)
+                                          self.ddf_setfamily.famsize,
+                                          self.ddf_setfamily.setsize)
 
     property set_family_matrix:
         def __get__(self):
@@ -978,24 +978,25 @@ cdef class Polyhedron(NumberTypeable):
     def get_vertex_adjacency_list(self):
         # if rep_type is generator, the input adjacency is the vertex adjacency
         if self.dd_poly:
-            if self.dd_poly.representation == 2:
+            if self.dd_poly.representation == 2: # if generator representation
                 return _make_dd_setfamily(dd_CopyInputAdjacency(self.dd_poly))
             else:
                 return _make_dd_setfamily(dd_CopyAdjacency(self.dd_poly))
         else:
-            if self.dd_poly.representation == 2:
+            if self.ddf_poly.representation == <ddf_RepresentationType>2:
                 return _make_ddf_setfamily(ddf_CopyInputAdjacency(self.ddf_poly))
             else:
                 return _make_ddf_setfamily(ddf_CopyAdjacency(self.ddf_poly))
 
     def get_facet_adjacency_list(self):
+        # if rep_type is generator, the input adjacency is the vertex adjacency
         if self.dd_poly:
-            if self.dd_poly.representation == 2:
+            if self.dd_poly.representation == 2: # if generator representation
                 return _make_dd_setfamily(dd_CopyAdjacency(self.dd_poly))
             else:
                 return _make_dd_setfamily(dd_CopyInputAdjacency(self.dd_poly))
         else:
-            if self.dd_poly.representation == 2:
+            if self.ddf_poly.representation == <ddf_RepresentationType>2:
                 return _make_ddf_setfamily(ddf_CopyAdjacency(self.ddf_poly))
             else:
                 return _make_ddf_setfamily(ddf_CopyInputAdjacency(self.ddf_poly))

--- a/cdd.pyx
+++ b/cdd.pyx
@@ -761,7 +761,7 @@ cdef class SetFamily(NumberTypeable):
             dd_WriteSetFamily(pfile, self.dd_setfamily)
         else:
             ddf_WriteSetFamily(pfile, self.ddf_setfamily)
-        return _tmpread(pfile).rstrip('\n')
+        return _tmpread(pfile).replace(' \n', '\n').rstrip('\n')
 
     def __init__(self, *args, **kwargs):
         # overriding this to prevent base class constructor to be called

--- a/cdd.pyx
+++ b/cdd.pyx
@@ -975,11 +975,30 @@ cdef class Polyhedron(NumberTypeable):
         else:
             return _make_ddf_matrix(ddf_CopyGenerators(self.ddf_poly))
 
-    def get_adjacency_list(self):
+    def get_vertex_adjacency_list(self):
+        # if rep_type is generator, the input adjacency is the vertex adjacency
         if self.dd_poly:
-            return _make_dd_setfamily(dd_CopyAdjacency(self.dd_poly))
+            if self.dd_poly.representation == 2:
+                return _make_dd_setfamily(dd_CopyInputAdjacency(self.dd_poly))
+            else:
+                return _make_dd_setfamily(dd_CopyAdjacency(self.dd_poly))
         else:
-            return _make_ddf_setfamily(ddf_CopyAdjacency(self.ddf_poly))
+            if self.dd_poly.representation == 2:
+                return _make_ddf_setfamily(ddf_CopyInputAdjacency(self.ddf_poly))
+            else:
+                return _make_ddf_setfamily(ddf_CopyAdjacency(self.ddf_poly))
+
+    def get_facet_adjacency_list(self):
+        if self.dd_poly:
+            if self.dd_poly.representation == 2:
+                return _make_dd_setfamily(dd_CopyAdjacency(self.dd_poly))
+            else:
+                return _make_dd_setfamily(dd_CopyInputAdjacency(self.dd_poly))
+        else:
+            if self.dd_poly.representation == 2:
+                return _make_ddf_setfamily(ddf_CopyAdjacency(self.ddf_poly))
+            else:
+                return _make_ddf_setfamily(ddf_CopyInputAdjacency(self.ddf_poly))
 
 # module initialization code comes here
 # initialize module constants

--- a/docs/polyhedron.rst
+++ b/docs/polyhedron.rst
@@ -117,8 +117,8 @@ end
 >>> # The numbering in the sets starts from zero,
 >>> # so the vertices adjacent to the first vertex (vertex 0)
 >>> # have indices 1 and 3:
->>> print(adjacency_list[0])
-frozenset([1, 3])
+>>> print(list(adjacency_list[0]))
+[1, 3]
 >>> # Finally, we can output the vertex adjacency matrix
 >>> print(adjacency_list.set_family_matrix)
 [[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 1, 0]]

--- a/docs/polyhedron.rst
+++ b/docs/polyhedron.rst
@@ -41,6 +41,16 @@ Methods and Attributes
         column vector with `n` ones followed by `s` zeroes, and `V` is the
         stacked matrix of `n` vertex row vectors on top of `s` ray row vectors.
 
+.. method:: Polyhedron.get_adjacency_list()
+
+        Get the adjacency list for the polyhedron.
+
+        :returns: Adjacency list.
+        :rtype: :class:`~cdd.SetFamily`
+
+	The adjacency list of a polyhedron is the list of sets of vertices
+	which are adjacent to each vertex.
+
 .. attribute:: Polyhedron.rep_type
 
         Representation (see :class:`~cdd.RepType`).
@@ -50,10 +60,10 @@ Methods and Attributes
     The H-representation and/or V-representation are not guaranteed to
     be minimal, that is, they can still contain redundancy.
 
-Example
--------
+Examples
+--------
 
-This is the sampleh1.ine example that comes with cddlib.
+1) This is the sampleh1.ine example that comes with cddlib.
 
 >>> import cdd
 >>> mat = cdd.Matrix([[2,-1,-1,0],[0,1,0,0],[0,0,1,0]], number_type='fraction')
@@ -79,3 +89,36 @@ begin
 end
 >>> print(list(ext.lin_set)) # note: first row is 0, so fourth row is 3
 [3]
+
+
+2) The following example illustrates the use of the get_adjacency_list method.
+
+>>> import cdd
+>>> # We start with the H-representation for a square
+>>> mat = cdd.Matrix([[1, 1, 0], [1, 0, 1], [1, -1, 0], [1, 0, -1]])
+>>> mat.rep_type = cdd.RepType.INEQUALITY
+>>> poly = cdd.Polyhedron(mat)
+>>> adjacency_list = poly.get_adjacency_list()
+>>> # We can output to screen as done by cddlib
+>>> print(adjacency_list)
+begin
+  4    4
+ 1 2 : 2 4
+ 2 2 : 1 3
+ 3 2 : 2 4
+ 4 2 : 1 3
+end
+>>> # We can also use some attributes of the SetFamily class
+>>> print(adjacency_list.family_size)
+4
+>>> print(adjacency_list.set_size)
+4
+>>> # The adjacencies are stored as a tuple of frozensets
+>>> # The numbering in the sets starts from zero,
+>>> # so the vertices adjacent to the first vertex (vertex 0)
+>>> # have indices 1 and 3:
+>>> print(adjacency_list[0])
+frozenset([1, 3])
+>>> # Finally, we can output the vertex adjacency matrix
+>>> print(adjacency_list.set_family_matrix)
+[[0, 1, 0, 1], [1, 0, 1, 0], [0, 1, 0, 1], [1, 0, 1, 0]]

--- a/docs/polyhedron.rst
+++ b/docs/polyhedron.rst
@@ -41,15 +41,25 @@ Methods and Attributes
         column vector with `n` ones followed by `s` zeroes, and `V` is the
         stacked matrix of `n` vertex row vectors on top of `s` ray row vectors.
 
-.. method:: Polyhedron.get_adjacency_list()
+.. method:: Polyhedron.get_vertex_adjacency_list()
 
-        Get the adjacency list for the polyhedron.
+        Get the vertex adjacency list for the polyhedron.
 
-        :returns: Adjacency list.
+        :returns: Vertex adjacency list.
         :rtype: :class:`~cdd.SetFamily`
 
-	The adjacency list of a polyhedron is the list of sets of vertices
+	The vertex adjacency list of a polyhedron is the list of sets of vertices
 	which are adjacent to each vertex.
+
+.. method:: Polyhedron.get_facet_adjacency_list()
+
+        Get the facet adjacency list for the polyhedron.
+
+        :returns: Facet adjacency list.
+        :rtype: :class:`~cdd.SetFamily`
+
+	The facet adjacency list of a polyhedron is the list of sets of facets
+	which are adjacent to each facet.
 
 .. attribute:: Polyhedron.rep_type
 
@@ -98,7 +108,7 @@ end
 >>> mat = cdd.Matrix([[1, 1, 0], [1, 0, 1], [1, -1, 0], [1, 0, -1]])
 >>> mat.rep_type = cdd.RepType.INEQUALITY
 >>> poly = cdd.Polyhedron(mat)
->>> adjacency_list = poly.get_adjacency_list()
+>>> adjacency_list = poly.get_vertex_adjacency_list()
 >>> # We can output to screen as done by cddlib
 >>> print(adjacency_list)
 begin

--- a/test/test_adjacency_list.py
+++ b/test/test_adjacency_list.py
@@ -3,7 +3,7 @@ import nose
 from fractions import Fraction
 
 
-def test_vertex_adjacency_list():
+def test_vertex_adjacency_list_fraction():
 
     # The following lines test that poly.get_adjacency_list()
     # returns the correct adjacencies.
@@ -15,7 +15,7 @@ def test_vertex_adjacency_list():
                       [1, -1, 0, 0],
                       [1, 0, -1, 0],
                       [1, 0, 0, -1]],
-                     number_type=None)
+                     number_type='fraction')
     mat.rep_type = cdd.RepType.INEQUALITY
     poly = cdd.Polyhedron(mat)
     adjacency_list = poly.get_vertex_adjacency_list()
@@ -46,7 +46,7 @@ def test_vertex_adjacency_list():
         nose.tools.assert_equal(adjacency_list.set_family_matrix[i],
                                 [1 if j in adjacencies[i] else 0 for j in range(8)])
 
-def test_facet_adjacency_list():
+def test_facet_adjacency_list_fraction():
     # This matrix is the same as in vtest_vo.ine
     mat = cdd.Matrix([[0, 0, 0, 1],
                       [5, -4, -2, 1],
@@ -54,6 +54,74 @@ def test_facet_adjacency_list():
                       [16, -8, 0, 1],
                       [16, 0, -8, 1],
                       [32, -8, -8, 1]], number_type='fraction')
+
+    mat.rep_type = cdd.RepType.INEQUALITY
+    poly = cdd.Polyhedron(mat)
+
+    adjacencies = [[1, 2, 3, 4, 6],
+                   [0, 2, 3, 5],
+                   [0, 1, 4, 5],
+                   [0, 1, 5, 6],
+                   [0, 2, 5, 6],
+                   [1, 2, 3, 4, 6],
+                   [0, 3, 4, 5]]
+
+    adjacency_list = poly.get_facet_adjacency_list()
+    for i in range(7):
+        nose.tools.assert_equal(list(adjacency_list[i]), adjacencies[i])
+
+
+def test_vertex_adjacency_list_float():
+
+    # The following lines test that poly.get_adjacency_list()
+    # returns the correct adjacencies.
+
+    # We start with the H-representation for a cube
+    mat = cdd.Matrix([[1, 1, 0 ,0],
+                      [1, 0, 1, 0],
+                      [1, 0, 0, 1],
+                      [1, -1, 0, 0],
+                      [1, 0, -1, 0],
+                      [1, 0, 0, -1]],
+                     number_type='float')
+    mat.rep_type = cdd.RepType.INEQUALITY
+    poly = cdd.Polyhedron(mat)
+    adjacency_list = poly.get_vertex_adjacency_list()
+
+    # Family size should equal the number of vertices of the cube (8)
+    nose.tools.assert_equal(adjacency_list.family_size, len(adjacency_list))
+    nose.tools.assert_equal(adjacency_list.family_size, 8)
+
+    # Set size should also equal the number of vertices of the cube (8)
+    nose.tools.assert_equal(adjacency_list.set_size, 8)
+
+    # All the vertices of the cube should be connected by three other vertices
+    nose.tools.assert_equal([len(adj) for adj in adjacency_list], [3]*8)
+
+    # The vertices must be numbered consistently
+    # The first vertex is adjacent to the second, fourth and eighth
+    # (note the conversion to a pythonic numbering system)
+    adjacencies = [[1, 3, 7],
+                   [0, 2, 6],
+                   [1, 3, 4],
+                   [0, 2, 5],
+                   [2, 5, 6],
+                   [3, 4, 7],
+                   [1, 4, 7],
+                   [0, 5, 6]]
+    for i in range(8):
+        nose.tools.assert_equal(list(adjacency_list[i]), adjacencies[i])
+        nose.tools.assert_equal(adjacency_list.set_family_matrix[i],
+                                [1 if j in adjacencies[i] else 0 for j in range(8)])
+
+def test_facet_adjacency_list_float():
+    # This matrix is the same as in vtest_vo.ine
+    mat = cdd.Matrix([[0, 0, 0, 1],
+                      [5, -4, -2, 1],
+                      [5, -2, -4, 1],
+                      [16, -8, 0, 1],
+                      [16, 0, -8, 1],
+                      [32, -8, -8, 1]], number_type='float')
 
     mat.rep_type = cdd.RepType.INEQUALITY
     poly = cdd.Polyhedron(mat)

--- a/test/test_adjacency_list.py
+++ b/test/test_adjacency_list.py
@@ -3,7 +3,7 @@ import nose
 from fractions import Fraction
 
 
-def test_adjacency_list():
+def test_vertex_adjacency_list():
 
     # The following lines test that poly.get_adjacency_list()
     # returns the correct adjacencies.
@@ -18,7 +18,7 @@ def test_adjacency_list():
                      number_type=None)
     mat.rep_type = cdd.RepType.INEQUALITY
     poly = cdd.Polyhedron(mat)
-    adjacency_list = poly.get_adjacency_list()
+    adjacency_list = poly.get_vertex_adjacency_list()
 
     # Family size should equal the number of vertices of the cube (8)
     nose.tools.assert_equal(adjacency_list.family_size, len(adjacency_list))

--- a/test/test_adjacency_list.py
+++ b/test/test_adjacency_list.py
@@ -2,43 +2,46 @@ import cdd
 import nose
 from fractions import Fraction
 
-# The following lines test that poly.get_adjacency_list()
-# returns the correct adjacencies.
 
-# We start with the H-representation for a cube
-mat = cdd.Matrix([[1, 1, 0 ,0],
-                  [1, 0, 1, 0],
-                  [1, 0, 0, 1],
-                  [1, -1, 0, 0],
-                  [1, 0, -1, 0],
-                  [1, 0, 0, -1]],
-                 number_type=None)
-mat.rep_type = cdd.RepType.INEQUALITY
-poly = cdd.Polyhedron(mat)
-adjacency_list = poly.get_adjacency_list()
+def test_adjacency_list():
 
-# Family size should equal the number of vertices of the cube (8)
-nose.tools.assert_equal(adjacency_list.family_size, len(adjacency_list))
-nose.tools.assert_equal(adjacency_list.family_size, 8)
+    # The following lines test that poly.get_adjacency_list()
+    # returns the correct adjacencies.
 
-# Set size should also equal the number of vertices of the cube (8)
-nose.tools.assert_equal(adjacency_list.set_size, 8)
+    # We start with the H-representation for a cube
+    mat = cdd.Matrix([[1, 1, 0 ,0],
+                      [1, 0, 1, 0],
+                      [1, 0, 0, 1],
+                      [1, -1, 0, 0],
+                      [1, 0, -1, 0],
+                      [1, 0, 0, -1]],
+                     number_type=None)
+    mat.rep_type = cdd.RepType.INEQUALITY
+    poly = cdd.Polyhedron(mat)
+    adjacency_list = poly.get_adjacency_list()
 
-# All the vertices of the cube should be connected by three other vertices
-nose.tools.assert_equal([len(adj) for adj in adjacency_list], [3]*8)
+    # Family size should equal the number of vertices of the cube (8)
+    nose.tools.assert_equal(adjacency_list.family_size, len(adjacency_list))
+    nose.tools.assert_equal(adjacency_list.family_size, 8)
 
-# The vertices must be numbered consistently
-# The first vertex is adjacent to the second, fourth and eighth
-# (note the conversion to a pythonic numbering system)
-adjacencies = [frozenset([1, 3, 7]),
-               frozenset([0, 2, 6]),
-               frozenset([1, 3, 4]),
-               frozenset([0, 2, 5]),
-               frozenset([2, 5, 6]),
-               frozenset([3, 4, 7]),
-               frozenset([1, 4, 7]),
-               frozenset([0, 5, 6])]
-for i in range(8):
-    nose.tools.assert_equal(adjacency_list[i], adjacencies[i])
-    nose.tools.assert_equal(adjacency_list.set_family_matrix[i],
-                            [1 if j in adjacencies[i] else 0 for j in range(8)])
+    # Set size should also equal the number of vertices of the cube (8)
+    nose.tools.assert_equal(adjacency_list.set_size, 8)
+
+    # All the vertices of the cube should be connected by three other vertices
+    nose.tools.assert_equal([len(adj) for adj in adjacency_list], [3]*8)
+
+    # The vertices must be numbered consistently
+    # The first vertex is adjacent to the second, fourth and eighth
+    # (note the conversion to a pythonic numbering system)
+    adjacencies = [[1, 3, 7],
+                   [0, 2, 6],
+                   [1, 3, 4],
+                   [0, 2, 5],
+                   [2, 5, 6],
+                   [3, 4, 7],
+                   [1, 4, 7],
+                   [0, 5, 6]]
+    for i in range(8):
+        nose.tools.assert_equal(list(adjacency_list[i]), adjacencies[i])
+        nose.tools.assert_equal(adjacency_list.set_family_matrix[i],
+                                [1 if j in adjacencies[i] else 0 for j in range(8)])

--- a/test/test_adjacency_list.py
+++ b/test/test_adjacency_list.py
@@ -45,3 +45,27 @@ def test_vertex_adjacency_list():
         nose.tools.assert_equal(list(adjacency_list[i]), adjacencies[i])
         nose.tools.assert_equal(adjacency_list.set_family_matrix[i],
                                 [1 if j in adjacencies[i] else 0 for j in range(8)])
+
+def test_facet_adjacency_list():
+    # This matrix is the same as in vtest_vo.ine
+    mat = cdd.Matrix([[0, 0, 0, 1],
+                      [5, -4, -2, 1],
+                      [5, -2, -4, 1],
+                      [16, -8, 0, 1],
+                      [16, 0, -8, 1],
+                      [32, -8, -8, 1]], number_type='fraction')
+
+    mat.rep_type = cdd.RepType.INEQUALITY
+    poly = cdd.Polyhedron(mat)
+
+    adjacencies = [[1, 2, 3, 4, 6],
+                   [0, 2, 3, 5],
+                   [0, 1, 4, 5],
+                   [0, 1, 5, 6],
+                   [0, 2, 5, 6],
+                   [1, 2, 3, 4, 6],
+                   [0, 3, 4, 5]]
+
+    adjacency_list = poly.get_facet_adjacency_list()
+    for i in range(7):
+        nose.tools.assert_equal(list(adjacency_list[i]), adjacencies[i])

--- a/test/test_adjacency_list.py
+++ b/test/test_adjacency_list.py
@@ -1,0 +1,44 @@
+import cdd
+import nose
+from fractions import Fraction
+
+# The following lines test that poly.get_adjacency_list()
+# returns the correct adjacencies.
+
+# We start with the H-representation for a cube
+mat = cdd.Matrix([[1, 1, 0 ,0],
+                  [1, 0, 1, 0],
+                  [1, 0, 0, 1],
+                  [1, -1, 0, 0],
+                  [1, 0, -1, 0],
+                  [1, 0, 0, -1]],
+                 number_type=None)
+mat.rep_type = cdd.RepType.INEQUALITY
+poly = cdd.Polyhedron(mat)
+adjacency_list = poly.get_adjacency_list()
+
+# Family size should equal the number of vertices of the cube (8)
+nose.tools.assert_equal(adjacency_list.family_size, len(adjacency_list))
+nose.tools.assert_equal(adjacency_list.family_size, 8)
+
+# Set size should also equal the number of vertices of the cube (8)
+nose.tools.assert_equal(adjacency_list.set_size, 8)
+
+# All the vertices of the cube should be connected by three other vertices
+nose.tools.assert_equal([len(adj) for adj in adjacency_list], [3]*8)
+
+# The vertices must be numbered consistently
+# The first vertex is adjacent to the second, fourth and eighth
+# (note the conversion to a pythonic numbering system)
+adjacencies = [frozenset([1, 3, 7]),
+               frozenset([0, 2, 6]),
+               frozenset([1, 3, 4]),
+               frozenset([0, 2, 5]),
+               frozenset([2, 5, 6]),
+               frozenset([3, 4, 7]),
+               frozenset([1, 4, 7]),
+               frozenset([0, 5, 6])]
+for i in range(8):
+    nose.tools.assert_equal(adjacency_list[i], adjacencies[i])
+    nose.tools.assert_equal(adjacency_list.set_family_matrix[i],
+                            [1 if j in adjacencies[i] else 0 for j in range(8)])


### PR DESCRIPTION
This PR exposes cddlib's adjacency list (addressing Issue #32). It includes:
- A new SetFamily class, which mirrors cddlib's set_family structure.
- A new method `Polyhedron().get_adjacency_list()`, which returns a SetFamily instance containing the adjacency list (stored as a tuple of frozensets)
- A test checking that the output of the new method is correct for a 3D cube
- Updated documentation, including a new example.

