### PR TITLE
Use 0-indexing for variables removed via `block_elimination`

### DIFF
--- a/cython/pycddlib.pxi
+++ b/cython/pycddlib.pxi
@@ -1172,8 +1172,8 @@ def fourier_elimination(mat: Matrix) -> Matrix:
     return matrix_from_ptr_with_error(dd_mat, error)
 
 
-def block_elimination(mat: Matrix, col_set: Container[int]) -> Matrix:
-    """Eliminate the variables *col_set* from the system of linear inequalities *mat*.
+def block_elimination(mat: Matrix, var_set: Container[int]) -> Matrix:
+    """Eliminate the variables *var_set* from the system of linear inequalities *mat*.
     It does this by using the generators of the dual linear system,
     where the generators are calculated using the double description algorithm.
 
@@ -1192,7 +1192,7 @@ def block_elimination(mat: Matrix, col_set: Container[int]) -> Matrix:
     cdef dd_ErrorType error = dd_NoError
     set_initialize(&dd_colset, mat.dd_mat.colsize)
     try:
-        _set_set(dd_colset, col_set, True)
+        _set_set(dd_colset, var_set, True)
         dd_mat = dd_BlockElimination(mat.dd_mat, dd_colset, &error)
         return matrix_from_ptr_with_error(dd_mat, error)
     finally:

--- a/cython/pycddlib.pxi
+++ b/cython/pycddlib.pxi
@@ -89,14 +89,15 @@ cdef _get_set(set_type set_):
         elem for elem in range(set_[0]) if set_member(elem + 1, set_)
     }
 
-cdef _set_set(set_type set_, elems):
+cdef _set_set(set_type set_, elems, bool is_var_ind=False):
     # set elements of set_type by elements from a Python Container
     cdef unsigned long elem
+    offset = 2 if is_var_ind else 1
     for elem in range(set_[0]):
         if elem in elems:
-            set_addelem(set_, elem + 1)
+            set_addelem(set_, elem + offset)
         else:
-            set_delelem(set_, elem + 1)
+            set_delelem(set_, elem + offset)
 
 cdef setfam_from_ptr(dd_SetFamilyPtr dd_setfam):
     # create Python Sequence[Set] from dd_SetFamilyPtr, and
@@ -1191,7 +1192,7 @@ def block_elimination(mat: Matrix, col_set: Container[int]) -> Matrix:
     cdef dd_ErrorType error = dd_NoError
     set_initialize(&dd_colset, mat.dd_mat.colsize)
     try:
-        _set_set(dd_colset, col_set)
+        _set_set(dd_colset, col_set, True)
         dd_mat = dd_BlockElimination(mat.dd_mat, dd_colset, &error)
         return matrix_from_ptr_with_error(dd_mat, error)
     finally:

--- a/test/test_block_elimination.py
+++ b/test/test_block_elimination.py
@@ -7,7 +7,7 @@ def test_block_elimination_1() -> None:
     # 0 <= 1 + a + b + c + d,  0 <= 1 + 2a - b - c - d
     array = [[1, 1, 1, 1, 1], [1, 2, -1, -1, -1]]
     mat1 = cdd.matrix_from_array(array, rep_type=cdd.RepType.INEQUALITY)
-    mat2 = cdd.block_elimination(mat1, {2, 3, 4})
+    mat2 = cdd.block_elimination(mat1, {1, 2, 3})
     # 0 <= 2 + 3a
     assert_matrix_almost_equal(mat2.array, [[2, 3]])
     assert mat2.lin_set == set()
@@ -23,7 +23,7 @@ def test_block_elimination_2() -> None:
     ]
     mat1 = cdd.matrix_from_array(array, rep_type=cdd.RepType.INEQUALITY)
     # eliminate last variable, same as fourier
-    mat2 = cdd.block_elimination(mat1, {3})
+    mat2 = cdd.block_elimination(mat1, {2})
     assert_matrix_almost_equal(
         mat2.array,
         [
@@ -39,7 +39,7 @@ def test_block_elimination_3() -> None:
     # 0 = -2 + x + y, 0 <= y
     array = [[-2, 1, 1], [0, 0, 1]]
     mat1 = cdd.matrix_from_array(array, rep_type=cdd.RepType.INEQUALITY, lin_set=[0])
-    mat2 = cdd.block_elimination(mat1, {2})
+    mat2 = cdd.block_elimination(mat1, {1})
     # 0 <= 2 - x
     assert_matrix_almost_equal(mat2.array, [[2, -1]])
     assert mat2.lin_set == set()


### PR DESCRIPTION
## Context

Python uses 0-indexing while `cddlib` uses 1-indexing for both rows and columns of the array [b A].  When referencing rows and columns of that matrix, we use 0-indexing.  E.g. in `lin_set` of `matrix_from_array()` and the `ignored_rows` and `ignored_cols` of `matrix_rank()`.  

However, the same behavior is carried over to `block_elimination`.  The columns representing variables start from the second column, meaning the input to `col_set` needs to refer to the columns containing the variables rather than the index of the variables.  

The current documentation (see below) does not make this immediately clear as there is no mention that index 0 refers to the coefficient column b and not the first variable.
```Eliminate the variables col_set from the system of linear inequalities mat.```

This behavior has been discussed in https://github.com/mcmtroffaes/pycddlib/issues/90.

## Changes

Change the function signature of `block_elimination` so that it takes a set of 0-indexed variable indices.  These values are offset by 2 to recover the correct column indices.

## Drawback(s)

Not only does this break the API, but it also differs from `cdd`'s `dd_blockElimination` as that function expects the indices of the _columns_ to be removed, similar to the current implementation of `block_elimination`.

The changes here would bring `block_elimination` in line with `lrs`'s `eliminate` option.  There, one specifies the 1-indexed indices of variables to removed and there is no processing needed to select the correct columns of the matrix [b A] one wants to remove.  [lrs documentation](https://cgm.cs.mcgill.ca/%7Eavis/C/lrslib/USERGUIDE73.html#eliminate:~:text=column%20zero%20cannot%20be%20eliminated)

## Alternative(s)

One can change the documentation to explicitly point out that they need to refer to the columns associated with the variables they want to remove.  I.e. provide a set of 1-indexed indices of the variables they want to remove.

## Tests
All tests pass when running `pytest test/*` locally.
<img width="3780" height="1592" alt="image" src="https://github.com/user-attachments/assets/32fc95e0-ebda-4bdb-9b18-870686ec0f1f" />
