### PR TITLE
Update `block_elimination` documentation and check for invalid index

### DIFF
--- a/cython/pycddlib.pxi
+++ b/cython/pycddlib.pxi
@@ -1176,6 +1176,12 @@ def block_elimination(mat: Matrix, col_set: Container[int]) -> Matrix:
     It does this by using the generators of the dual linear system,
     where the generators are calculated using the double description algorithm.
 
+    .. warning::
+        
+        You must specify the indices of the columns associated with the variable(s) you want to remove.
+        Column 0 refers to the coefficient vector `b` from the matrix [b A].
+        Thus, column 1 is associated with the 1st variable, etc.
+
     .. note::
 
         The output is not guaranteed to be minimal,
@@ -1186,6 +1192,8 @@ def block_elimination(mat: Matrix, col_set: Container[int]) -> Matrix:
     """
     if mat.dd_mat.representation != dd_Inequality:
         raise ValueError("rep_type must be INEQUALITY")
+    if 0 in col_set:
+        raise ValueError("Column indices must be > 0.")
     cdef set_type dd_colset = NULL
     cdef dd_MatrixPtr dd_mat = NULL
     cdef dd_ErrorType error = dd_NoError

--- a/test/test_block_elimination.py
+++ b/test/test_block_elimination.py
@@ -1,3 +1,4 @@
+from pytest import raises
 from test import assert_matrix_almost_equal
 
 import cdd
@@ -43,3 +44,11 @@ def test_block_elimination_3() -> None:
     # 0 <= 2 - x
     assert_matrix_almost_equal(mat2.array, [[2, -1]])
     assert mat2.lin_set == set()
+
+
+def test_block_elimination_4() -> None:
+    # 0 = -2 + x + y, 0 <= y
+    array = [[-2, 1, 1], [0, 0, 1]]
+    mat = cdd.matrix_from_array(array, rep_type=cdd.RepType.INEQUALITY, lin_set=[0])
+    with raises(ValueError):
+        cdd.block_elimination(mat, {0})


### PR DESCRIPTION
See https://github.com/mcmtroffaes/pycddlib/pull/91 for context.  This PR is for https://github.com/mcmtroffaes/pycddlib/issues/90.

For this PR, a warning is added in the documentation and the code now checks to make sure that 0 is never passed in as an index of a variable to be removed.  This addresses the shortcomings in the linked PR as the API remains unchanged.